### PR TITLE
fix deprecation error for mysql adapter

### DIFF
--- a/lib/dm-is-reflective/is/adapters/mysql_adapter.rb
+++ b/lib/dm-is-reflective/is/adapters/mysql_adapter.rb
@@ -48,7 +48,7 @@ module DataMapper
         when /\w*INT(EGER)?( SIGNED| UNSIGNED)?( ZEROFILL)?/
                                               ; Integer
         when /(DOUBLE|FLOAT|DECIMAL)( SIGNED| UNSIGNED)?( ZEROFILL)?/
-                                              ; BigDecimal
+                                              ; Property::Decimal
         when /\w*BLOB|\w*BINARY|ENUM|SET|CHAR/; String
         when 'TIME'                           ; Time
         when 'DATE'                           ; Date


### PR DESCRIPTION
Hi,

today I got an deprecation error with DataMapper 1.2.0 and the MySQL adapter and fixed it (It was just using the old BigDecimal property type instead of Decimal). Would be glad if this got merged into the main repo.

Thanks!
