### PR TITLE
skip properties that start with digit, cannot be mapped to function

### DIFF
--- a/lib/dm-is-reflective/adapters/data_objects_adapter.rb
+++ b/lib/dm-is-reflective/adapters/data_objects_adapter.rb
@@ -119,7 +119,7 @@ module DmIsReflective::DataObjectsAdapter
     model.is(:reflective)
     model.storage_names[:default] = storage
     scope.const_set(Inflector.classify(storage), model)
-    model.__send__(:reflect, /.*/)
+    model.__send__(:reflect, /^[^\d].*/)
     model
   end
 


### PR DESCRIPTION
might want to change this later to add am '_' infront of the property, so you could create a function out of it. now the property is lost, but at least the rest is ok.