### PR TITLE
Allowing the existence of views in the Postgres database

### DIFF
--- a/lib/dm-is-reflective/adapters/postgres_adapter.rb
+++ b/lib/dm-is-reflective/adapters/postgres_adapter.rb
@@ -5,7 +5,7 @@ module DmIsReflective::PostgresAdapter
   def storages
     sql = <<-SQL
       SELECT table_name FROM "information_schema"."tables"
-      WHERE table_schema = current_schema()
+      WHERE table_schema = current_schema() AND table_type LIKE 'BASE TABLE'
     SQL
 
     select(Ext::String.compress_lines(sql))

--- a/lib/dm-is-reflective/adapters/postgres_adapter.rb
+++ b/lib/dm-is-reflective/adapters/postgres_adapter.rb
@@ -5,7 +5,7 @@ module DmIsReflective::PostgresAdapter
   def storages
     sql = <<-SQL
       SELECT table_name FROM "information_schema"."tables"
-      WHERE table_schema = current_schema() AND table_type LIKE 'BASE TABLE'
+      WHERE table_schema = current_schema() AND table_type = 'BASE TABLE'
     SQL
 
     select(Ext::String.compress_lines(sql))


### PR DESCRIPTION
Hi,

I have been using dm-is-reflective for a new project related to Postgis databases.
Thing is that with PostGIS postgres extensions, there are a couple of views that get created, and because the storages method, does not disambiguate between actual tables and views, I get the following error:

/home/cmiranda/.rvm/gems/ruby-2.3.1/gems/dm-core-1.2.1/lib/dm-core/model.rb:865:in `assert_valid_key': DB::GeographyColumn must have a key to be valid (DataMapper::IncompleteModelError)
	from /home/cmiranda/.rvm/gems/ruby-2.3.1/gems/dm-core-1.2.1/lib/dm-core/model.rb:141:in `finalize'
	from /home/cmiranda/.rvm/gems/ruby-2.3.1/gems/dm-is-reflective-1.3.1/lib/dm-is-reflective/reflective.rb:84:in `reflect'
	from /home/cmiranda/.rvm/gems/ruby-2.3.1/gems/dm-is-reflective-1.3.1/lib/dm-is-reflective/adapters/data_objects_adapter.rb:122:in `reflective_genclass'
	from /home/cmiranda/.rvm/gems/ruby-2.3.1/gems/dm-is-reflective-1.3.1/lib/dm-is-reflective/adapters/data_objects_adapter.rb:106:in `block in auto_genclass!'
	from /home/cmiranda/.rvm/gems/ruby-2.3.1/gems/dm-is-reflective-1.3.1/lib/dm-is-reflective/adapters/data_objects_adapter.rb:91:in `map'
	from /home/cmiranda/.rvm/gems/ruby-2.3.1/gems/dm-is-reflective-1.3.1/lib/dm-is-reflective/adapters/data_objects_adapter.rb:91:in `auto_genclass!'
	from /home/cmiranda/.rvm/gems/ruby-2.3.1/gems/dm-is-reflective-1.3.1/lib/dm-is-reflective/runner.rb:24:in `generate'
	from /home/cmiranda/.rvm/gems/ruby-2.3.1/gems/dm-is-reflective-1.3.1/lib/dm-is-reflective/runner.rb:18:in `run'
	from /home/cmiranda/.rvm/gems/ruby-2.3.1/gems/dm-is-reflective-1.3.1/bin/dm-is-reflective:4:in `<top (required)>'
	from /home/cmiranda/.rvm/gems/ruby-2.3.1/bin/dm-is-reflective:23:in `load'
	from /home/cmiranda/.rvm/gems/ruby-2.3.1/bin/dm-is-reflective:23:in `<main>'
	from /home/cmiranda/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `eval'
	from /home/cmiranda/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `<main>'

I don't know if the actual solution is the way to go, however with this small change I remove the error and get the needed info.

Looking forward for your feedback.

Tino